### PR TITLE
Fix ratings

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -44,7 +44,7 @@ class IMDBRatings {
 
   processRespAndSetRating(element, request) {
     var serverResponse = request.responseText;
-    var pattern = /ratingValue\"\>(.*?)\</;
+    var pattern = /"AggregateRatingButton__RatingScore.*?"\>(.*?)\</;
     var rating = null;
     var match_rating = serverResponse.match(pattern);
     if (match_rating != null) {


### PR DESCRIPTION
This pull request updates the regular expression used to find the rating in the markup. It uses the same selector as the similar [Show IMDB ratings](https://chrome.google.com/webstore/detail/show-imdb-ratings/mjljmcikmfemkogkhbohgcgbfaikoljg) extension.